### PR TITLE
feat: Disable tracing when Arize server not available, updates for GPT 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [2025/08/02]
+- simplified configuration of Arize vs. standard OpenAI client
+
 # [2025/07/26]
 
 - fixed bug when `AssistantMsg` with None content was added to history when tool calling in structured output `Agent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [2025/08/12]
+
+- GPT 5 set as default model for examples
+- Tracing silenced when Arize server not available
+- OpenAI SDK upgrade
+
 # [2025/08/02]
 
 - Easier configuration of `OpenAI` / `AzureOpenAI` clients in `GptOpenAI` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [2025/08/02]
-- simplified configuration of Arize vs. standard OpenAI client
+
+- Easier configuration of `OpenAI` / `AzureOpenAI` clients in `GptOpenAI` class
+- New class methods `from_openai()` & `from_azure_openai` in `GptOpenAI`
 
 # [2025/07/26]
 

--- a/examples/1_llm_generate.py
+++ b/examples/1_llm_generate.py
@@ -5,7 +5,7 @@ from llmbrix.msg import SystemMsg, UserMsg
 Generate answer with OpenAI GPT model.
 """
 
-MODEL = "gpt-4o-mini"
+MODEL = "gpt-5"
 SYSTEM_MSG = "You answer in pure Python code, no explanations."
 USER_MSG = "Compute how many items in 2 int arrays are present in both."
 

--- a/examples/2_llm_generate_structured.py
+++ b/examples/2_llm_generate_structured.py
@@ -11,7 +11,7 @@ from llmbrix.msg import SystemMsg, UserMsg
 Generate answer with OpenAI GPT model.
 """
 
-MODEL = "gpt-4o-mini"
+MODEL = "gpt-5-mini"
 SYSTEM_MSG = "You name 3 colors that are most similar to color from user."
 USER_MSG = "I chooose yellow!"
 

--- a/examples/2_llm_generate_structured.py
+++ b/examples/2_llm_generate_structured.py
@@ -1,3 +1,6 @@
+import os
+
+from openai import OpenAI
 from pydantic import BaseModel
 
 from llmbrix.gpt_openai import GptOpenAI
@@ -19,7 +22,7 @@ class SelectedColor(BaseModel):
 
 
 messages = [SystemMsg(content=SYSTEM_MSG), UserMsg(content=USER_MSG)]
-gpt = GptOpenAI(model=MODEL)
+gpt = GptOpenAI(model=MODEL, openai_client=OpenAI(api_key=os.getenv("OPENAI_API_KEY")))
 output: GptResponse = gpt.generate(messages, output_format=SelectedColor)
 messages.append(output.message)
 

--- a/examples/3_simple_chatbot.py
+++ b/examples/3_simple_chatbot.py
@@ -9,7 +9,7 @@ SYSTEM_MSG = "Be super brief."
 HIST_LIMIT = 5
 MODEL = "gpt-4o-mini"
 
-gpt = GptOpenAI.from_azure_openai(model=MODEL, api_key=os.getenv("OPENAI_API_KEY"))
+gpt = GptOpenAI.from_openai(model=MODEL, api_key=os.getenv("OPENAI_API_KEY"))
 chat_history = ChatHistory(max_turns=HIST_LIMIT)
 system_msg = SystemMsg(content=SYSTEM_MSG)
 agent = Agent(gpt=gpt, chat_history=chat_history, system_msg=system_msg)

--- a/examples/3_simple_chatbot.py
+++ b/examples/3_simple_chatbot.py
@@ -1,3 +1,5 @@
+import os
+
 from llmbrix.agent import Agent
 from llmbrix.chat_history import ChatHistory
 from llmbrix.gpt_openai import GptOpenAI
@@ -7,7 +9,7 @@ SYSTEM_MSG = "Be super brief."
 HIST_LIMIT = 5
 MODEL = "gpt-4o-mini"
 
-gpt = GptOpenAI(model=MODEL)
+gpt = GptOpenAI.from_azure_openai(model=MODEL, api_key=os.getenv("OPENAI_API_KEY"))
 chat_history = ChatHistory(max_turns=HIST_LIMIT)
 system_msg = SystemMsg(content=SYSTEM_MSG)
 agent = Agent(gpt=gpt, chat_history=chat_history, system_msg=system_msg)

--- a/examples/3_simple_chatbot.py
+++ b/examples/3_simple_chatbot.py
@@ -7,7 +7,7 @@ from llmbrix.msg import SystemMsg, UserMsg
 
 SYSTEM_MSG = "Be super brief."
 HIST_LIMIT = 5
-MODEL = "gpt-4o-mini"
+MODEL = "gpt-5-nano"
 
 gpt = GptOpenAI.from_openai(model=MODEL, api_key=os.getenv("OPENAI_API_KEY"))
 chat_history = ChatHistory(max_turns=HIST_LIMIT)

--- a/examples/4_tool_calling_chatbot.py
+++ b/examples/4_tool_calling_chatbot.py
@@ -11,7 +11,7 @@ from llmbrix.tools import GetDatetime, ListDir
 
 SYSTEM_MSG = "Be super brief. Use provided tools to either get current datetime or list files in dir."
 HIST_LIMIT = 5
-MODEL = "gpt-4o-mini"
+MODEL = "gpt-5-mini"
 
 gpt = GptOpenAI(model=MODEL)
 chat_history = ChatHistory(max_turns=HIST_LIMIT)

--- a/examples/5_chatbot_with_prompt/chatbot.py
+++ b/examples/5_chatbot_with_prompt/chatbot.py
@@ -11,7 +11,7 @@ from llmbrix.tools import AboutMe, GetDatetime, ListDir
 
 RUN_START = time()
 HIST_LIMIT = 5
-MODEL = "gpt-4o-mini"
+MODEL = "gpt-5-mini"
 PROMPT_DIR = "./prompts"
 CHATBOT_NAME = "Rupert"
 

--- a/examples/6_structured_chatbot.py
+++ b/examples/6_structured_chatbot.py
@@ -24,7 +24,7 @@ PROMPT = (
 )
 
 HIST_LIMIT = 10
-MODEL = "gpt-4o-mini"
+MODEL = "gpt-5-nano"
 
 INPUT_MSGS = ["lz -la", "cd //tmp", "cat /tmp/myfile" "try in local tmp"]
 

--- a/llmbrix/gpt_openai.py
+++ b/llmbrix/gpt_openai.py
@@ -15,7 +15,9 @@ T = TypeVar("T", bound=BaseModel)
 
 class GptOpenAI:
     """
-    Wraps OpenAI GPT responses API.
+    GPT wrapper used to generate tokens via OpenAI API.
+    Supports non-reasoning GPT models, tool calling and structured outputs.
+    Internally uses responses API.
     """
 
     def __init__(
@@ -60,7 +62,7 @@ class GptOpenAI:
                 self.client = AzureOpenAI()
 
     @classmethod
-    def from_openai_cfg(cls, model: str, api_key: str, **kwargs) -> "GptOpenAI":
+    def from_openai(cls, model: str, api_key: str, **kwargs) -> "GptOpenAI":
         """
         Initialize GptOpenAI instance with standard OpenAI API.
 

--- a/llmbrix/gpt_openai.py
+++ b/llmbrix/gpt_openai.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional, Type, TypeVar, cast
 
-from openai import AzureOpenAI, OpenAI
+from openai import AzureOpenAI, OpenAI, OpenAIError
 from openai.types.responses import ResponseFunctionToolCall
 from pydantic import BaseModel
 
@@ -11,7 +11,6 @@ from llmbrix.msg import AssistantMsg, Msg, ToolRequestMsg
 from llmbrix.tool import Tool
 
 T = TypeVar("T", bound=BaseModel)
-DEFAULT_TIMEOUT = 60
 
 
 class GptOpenAI:
@@ -21,55 +20,85 @@ class GptOpenAI:
 
     def __init__(
         self,
-        model: str = None,
+        model: str,
+        openai_client: OpenAI | AzureOpenAI = None,
         tools: list[Tool] = None,
         output_format: Optional[Type[T]] = None,
-        api_timeout: int = DEFAULT_TIMEOUT,
-        openai_client: OpenAI | AzureOpenAI = None,
+        api_timeout: int = 60,
         **responses_kwargs,
     ):
         """
         Parameters passed here will be set as defaults.
-
         Any value passed to these parameters in `generate()` will override these defaults.
 
-        Note `model` has to be set either here or in `generate()` function.
-
-        If no `openai_client` then `OPENAI_API_KEY` env variable must be set in order to
-        initialize default OpenAI client.
-
-        :param model: name of GPT model to use
-        :param tools: (optional) list of Tool child instances to register to LLM as tools to be used
+        :param model: name of GPT model to use. Reasoning models are not supported.
+        :param openai_client: `OpenAI` or `AzureOpenAI` object from official OpenAI SDK.
+                              If not provided then:
+                                  1. `OpenAI` client is initialized from `OPENAI_API_KEY` env var.
+                                  2. If `OPENAI_API_KEY` not provided either then` AzureOpenAI` client is
+                                     initialized from env vars. At minimum set following vars:
+                                        - `AZURE_OPENAI_API_KEY`
+                                        - `OPENAI_API_VERSION`
+                                        - `AZURE_OPENAI_ENDPOINT`
+                              Refer to official SDK `OpenAI` and `AzureOpenAI` class docs for more details.
+        :param tools: (optional) list of Tool instances to register to LLM as tools to be used
         :param output_format: (optional) Pydantic BaseModel instance to define output format of the LLM.
         :param api_timeout: timeout for OpenAI API in seconds. Default is 60s
-        :param openai_client: (optional) Specify custom OpenAI/AzureOpenAI client to be used.
-                              If none provided then default OpenAI() client is initialized.
-
-                              Example: Initialize AzureOpenAI client:
-
-                                ```python
-                                    import os
-                                    from openai import AzureOpenAI
-
-                                    client = AzureOpenAI(
-                                        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-                                        api_version="2024-07-01-preview",
-                                        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT")
-                                    )
-                                ```
         :param responses_kwargs: (optional) any additional kwargs to be passed to responses API.
-                                 Note if output format is defined responses.parse is used.
-
         """
         self.model = model
         self.tools = tools
         self.output_format = output_format
         self.api_timeout = api_timeout
         self.responses_kwargs = responses_kwargs
-        if openai_client is not None:
+        if openai_client:
             self.client = openai_client
         else:
-            self.client = OpenAI()
+            try:
+                self.client = OpenAI()
+            except OpenAIError:
+                self.client = AzureOpenAI()
+
+    @classmethod
+    def from_openai_cfg(cls, model: str, api_key: str, **kwargs) -> "GptOpenAI":
+        """
+        Initialize GptOpenAI instance with standard OpenAI API.
+
+        :param model: name of GPT model to use. Reasoning models are not supported.
+        :param api_key: OpenAI API key.
+        :param kwargs: Kwargs passed to __init__ method. See DocString of __init__ for details.
+
+        :return: Instance of GptOpenAI with standard OpenAI client.
+        """
+        client = OpenAI(api_key=api_key)
+        return cls(model=model, openai_client=client, **kwargs)
+
+    @classmethod
+    def from_azure_openai(
+        cls,
+        model: str,
+        api_key: str,
+        api_version: str,
+        azure_endpoint: str,
+        azure_deployment: str,
+        **kwargs,
+    ) -> "GptOpenAI":
+        """
+        Initialize GptOpenAI instance from standard Azure OpenAI API args.
+
+        :param model: name of GPT model to use. Reasoning models are not supported.
+        :param api_key: Azure OpenAI API key.
+        :param api_version: Azure OpenAI API version.
+        :param azure_endpoint: Azure OpenAI API endpoint.
+        :param azure_deployment: Azure OpenAI API deployment.
+        :param kwargs: Kwargs passed to __init__ method. See DocString of __init__ for details.
+
+        :return: Instance of GptOpenAI with AzureOpenAI client.
+        """
+        client = AzureOpenAI(
+            api_key=api_key, api_version=api_version, azure_endpoint=azure_endpoint, azure_deployment=azure_deployment
+        )
+        return cls(model=model, openai_client=client, **kwargs)
 
     def __call__(self, *args, **kwargs) -> GptResponse:
         """
@@ -82,7 +111,6 @@ class GptOpenAI:
     def generate(
         self,
         messages: list[Msg],
-        model: str = None,
         tools: list[Tool] = None,
         output_format: Optional[Type[T]] = None,
         api_timeout: int = None,
@@ -95,7 +123,6 @@ class GptOpenAI:
         If provided here, they override those defaults.
 
         :param messages: list of messages for LLM to be used as input.
-        :param model: name of GPT model to use
         :param tools: (optional) list of Tool child instances to register to LLM as tools to be used
         :param output_format: (optional) Pydantic BaseModel instance to define output format of the LLM.
         :param api_timeout: timeout for OpenAI API in seconds. Default is set to 60s.
@@ -109,28 +136,22 @@ class GptOpenAI:
 
         :raises OpenAIResponseError: if an error field is returned from OpenAI responses API call
         """
-        model = model or self.model
         tools = tools or self.tools
         output_format = output_format or self.output_format
         api_timeout = self.api_timeout if api_timeout is None else api_timeout
         responses_kwargs = {**self.responses_kwargs, **responses_kwargs}
-        if not model:
-            raise ValueError(
-                "No model name has been provided. Either set default model name in __init__() or pass "
-                "it into this function."
-            )
 
         messages = [m.to_openai() for m in messages]
         tool_schemas = [t.openai_schema for t in tools] if tools else []
 
         if output_format is None:
             response = self.client.responses.create(
-                input=messages, model=model, tools=tool_schemas, timeout=api_timeout, **responses_kwargs
+                input=messages, model=self.model, tools=tool_schemas, timeout=api_timeout, **responses_kwargs
             )
         else:
             response = self.client.responses.parse(
                 input=messages,
-                model=model,
+                model=self.model,
                 tools=tool_schemas,
                 text_format=output_format,
                 timeout=api_timeout,

--- a/llmbrix/tracing.py
+++ b/llmbrix/tracing.py
@@ -1,3 +1,4 @@
+import socket
 from contextlib import contextmanager
 from typing import Callable
 
@@ -8,42 +9,82 @@ _tracer: Tracer = trace.get_tracer(__name__)
 _is_configured = False
 
 
+def _is_collector_reachable(host: str, port: int, timeout: float = 0.25) -> bool:
+    """Return True iff a TCP connection to host:port succeeds within timeout."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 def configure_arize_tracing(
     project_name: str,
     phoenix_collector_endpoint: str = "http://localhost:4317",
 ):
     """
-    Configures Phoenix + OpenInference tracing.
-    Must be called before importing any of instrumented libraries and modules (e.g. GptOpenAI, Agent, etc.)
+    Configures Phoenix + OpenInference tracing IFF everything is available & reachable.
+    Otherwise, stays completely silent and leaves a no-op tracer in place.
     """
     global _tracer, _is_configured
 
+    # Import deps lazily so a missing package silently disables tracing
     try:
+        from urllib.parse import urlparse
+
         from openinference.instrumentation.openai import OpenAIInstrumentor
         from phoenix.otel import register
+    except Exception:
+        # Any import problem => no tracing
+        _tracer = _NoopTracer()
+        _is_configured = False
+        return
 
-        tracer_provider = register(project_name=project_name, endpoint=phoenix_collector_endpoint, batch=True)
+    # Parse endpoint and preflight reachability before we register anything
+    try:
+        parsed = urlparse(phoenix_collector_endpoint)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 4317
+    except Exception:
+        # Malformed endpoint => no tracing
+        _tracer = _NoopTracer()
+        _is_configured = False
+        return
+
+    if not _is_collector_reachable(host, port):
+        # Collector not up => no tracing (prevents exporter retry spam)
+        _tracer = _NoopTracer()
+        _is_configured = False
+        return
+
+    # If we’re here, deps exist and collector is reachable; set up tracing.
+    try:
+        tracer_provider = register(
+            project_name=project_name,
+            endpoint=phoenix_collector_endpoint,
+            batch=True,  # keep Phoenix defaults
+        )
         OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
         _tracer = trace.get_tracer(__name__, tracer_provider=tracer_provider)
         _is_configured = True
-
-    except ImportError:
-        print("[tracing] Phoenix or OpenInference not available, using noop tracer.")
+    except Exception:
+        # Any runtime failure => fall back to no-op, keep quiet
+        _tracer = _NoopTracer()
+        _is_configured = False
 
 
 def get_tracer() -> Tracer:
     """
     Returns a tracer that always works.
-    If Phoenix is not configured, returns tracer with no-op `.chain()` decorator.
+    If Phoenix is not configured, returns tracer with no-op decorators.
     """
     if _is_configured:
         return _tracer
-
     return _NoopTracer()
 
 
 class _NoopTracer:
-    """A no-op tracer with a `chain()` decorator that does nothing."""
+    """A no-op tracer with decorators that do nothing, and a context manager span."""
 
     def start_as_current_span(self, name):
         return _noop_span(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ authors = [
     { name = "Matej Kvassay", email = "matejkvassay5@gmail.com" }
 ]
 description = "Low abstraction agentic LLM framework."
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "arize-phoenix-otel",
     "jinja2",
-    "openai",
+    "openai>=1.99.9",
     "openinference-instrumentation-openai",
     "opentelemetry-sdk",
     "pydantic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Matej Kvassay", email = "matejkvassay5@gmail.com" }
 ]
 description = "Low abstraction agentic LLM framework."
-version = "0.1.0a10"
+version = "0.1.0"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Matej Kvassay", email = "matejkvassay5@gmail.com" }
 ]
 description = "Low abstraction agentic LLM framework."
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
- GPT 5 set as default model for examples
- Tracing silenced when Arize server not available
- OpenAI SDK upgrade